### PR TITLE
Add `manifest.yml`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,11 @@
+name: netlify-plugin-chromium
+inputs:
+  - name: packageManager
+    description: Package manager to install Chromium with; npm or yarn.
+    default: npm
+  - name: setChromePathInEnv
+    description: If true, sets value of environment variable CHROME_PATH to location of local copy of Chromium binaries. This change is required by many tools relying on Chromium to be able to find it and launch it successfully (such as Lighthouse).
+    default: false
+  - name: failBuildOnError
+    description: If true and Chromium installation finished with failure, whole build will fail. Otherwise, only this plugin fails and the rest of the build proceeds as usual.
+    default: false

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/soofka/netlify-plugin-chromium#readme",
   "main": "lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "manifest.yml"
   ],
   "scripts": {
     "build": "rimraf lib && rollup src/index.js --file lib/index.js --format cjs && cpy src/manifest.yml lib",


### PR DESCRIPTION
This adds a `manifest.yml` (documentation [here](https://github.com/netlify/build#anatomy-of-a-plugin)) which describes some static properties about the plugin: `name` and `inputs`.